### PR TITLE
Update action name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action installs the IBM Cloud CLI and authenticates with IBM Cloud so you c
 
 ```yaml
 - name: Instal IBM Cloud CLI
-  uses: actions/ibmcloud-action@v1
+  uses: IBM/actions-ibmcloud-cli@0.0.8
   with:
     APIKEY: ${{ secrets.IBM_CLOUD_API_KEY }}
     CLOUD_REGION: us-south


### PR DESCRIPTION
As currently written, the example usage in the README has the incorrect org/repo names... this PR adds the correct names so that users can copy/paste the sample code block and use as is.

FYI @jjasghar 