### PR TITLE
Add weekly cron job for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 on:
   pull_request:
   push:
+  schedule:
+  - cron: '0 0 * * 0'
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
This allows us to react to any changes in the ibm cloud CLI itself that may break the installer

Successful tests from PR fork: https://github.com/Fryguy/actions-ibmcloud-cli/actions?query=branch%3Acron_test