### PR TITLE
Update supported platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Check basic CLI function
         run: ibmcloud --version
 
-  test-multiple-platforms:
+  test-all-platforms:
     strategy:
       matrix:
         os:
@@ -227,9 +227,9 @@ jobs:
         - ubuntu-22.04
         - ubuntu-22.04-arm
         - macos-latest
+        - macos-26
         - macos-15
         - macos-14
-        - macos-13
         - windows-latest
         - windows-2025
         - windows-2022

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The action works on these [GitHub-hosted runners](https://docs.github.com/en/act
 | OS      | Supported        |
 | ------- | ---------------- |
 | Ubuntu  | `ubuntu-24.04` (`ubuntu-latest`), `ubuntu-24.04-arm`, `ubuntu-22.04`, `ubuntu-22.04-arm` |
-| macOS   | `macos-15`, `macos-14` (`macos-latest`), `macos-13` |
-| Windows | `windows-2025`, `windows-2022` (`windows-latest`) |
+| macOS   | `macos-26`, `macos-15` (`macos-latest`), `macos-14` |
+| Windows | `windows-2025` (`windows-latest`), `windows-2022` |
 
 ## Contributing
 


### PR DESCRIPTION
Drop the deprecated macos-13, add macos-26, and adjust the -latest versions in the README.